### PR TITLE
Some readme/read_file fixes

### DIFF
--- a/web/build-project-list.pl
+++ b/web/build-project-list.pl
@@ -61,7 +61,9 @@ my $site_info = {
 		}
 		
 		$project ->{badge_has_tests} = $files{t} || $files{test} || $files{tests} ;
-		$project ->{badge_has_readme} = $files{README} ? "http://github.com/$project->{auth}/$project->{name}/blob/master/README" : undef;
+
+        my @readmes = @files{ qw/README README.pod README.md README.mkdn README.markdown/ };
+		$project ->{badge_has_readme} = scalar(@readmes) ? "http://github.com/$project->{auth}/$project->{name}/blob/master/README" : undef;
 		$project ->{badge_is_popular} = $repository->{repository}->{watchers} && $repository->{repository}->{watchers} > 50;
 		sleep(3) ; #We are allowed 60 calls/min = 1 api call per second, and we are wasting 3 per request so we sleep for 3 secs to make up
 		return;


### PR DESCRIPTION
People put README files in filenames other than just 'README' for formatting purposes, such as README.pod, etc.

Also eval { slurp ... } will always be undef because it dies inside the eval. Might as well use read_file since that's exported by default.
