### PR TITLE
change 'not set up' repo URLs

### DIFF
--- a/templates/root/index.html.ep
+++ b/templates/root/index.html.ep
@@ -77,7 +77,7 @@
               </a>
             </td>
             <td class="desc"><%= $dist->{description} %></td>
-            <td class="travis travis-<%= $dist->{travis_status} %> " >
+            <td class="travis travis-<%= $dist->{travis_status} %>">
               % if ( $dist->{travis_status} eq 'not set up') {
                 <a href="https://docs.travis-ci.com/user/languages/perl6">
                 <i class="glyphicon glyphicon-question-sign"></i>

--- a/templates/root/index.html.ep
+++ b/templates/root/index.html.ep
@@ -77,12 +77,13 @@
               </a>
             </td>
             <td class="desc"><%= $dist->{description} %></td>
-            <td class="travis travis-<%= $dist->{travis_status} %>">
-              <a href="<%= $dist->{travis_url} %>"
-                >
-                % if ( $dist->{travis_status} eq 'not set up' ) {
-                  <i class="glyphicon glyphicon-question-sign"></i>
-                % }
+            <td class="travis travis-<%= $dist->{travis_status} %> " >
+              % if ( $dist->{travis_status} eq 'not set up') {
+                <a href="https://docs.travis-ci.com/user/languages/perl6">
+                <i class="glyphicon glyphicon-question-sign"></i>
+              % }else{
+                 <a href="<%= $dist->{travis_url} %>">
+              % }
                 <%= $dist->{travis_status} %>
               </a>
             </td>


### PR DESCRIPTION
Change 'not set up' repo URLs to link to https://docs.travis-ci.com/user/languages/perl6

https://github.com/perl6/modules.perl6.org/issues/47