### PR TITLE
Fill stars, issues for modules on cpan

### DIFF
--- a/lib/ModulesPerl6/DbBuilder/Dist/Source/GitHub.pm
+++ b/lib/ModulesPerl6/DbBuilder/Dist/Source/GitHub.pm
@@ -78,6 +78,8 @@ sub load {
         %$dist,
         dist_source => 'github',
         url         => $repo->{html_url},
+        stargazer_url => $repo->{html_url} . '/stargazers',
+        issue_url => $repo->{html_url} . '/issues',
         repo_url    => $repo->{html_url},
         issues      => $repo->{open_issues_count} // 0,
         stars       => $repo->{stargazers_count}  // 0,

--- a/lib/ModulesPerl6/Model/Dists.pm
+++ b/lib/ModulesPerl6/Model/Dists.pm
@@ -77,6 +77,8 @@ sub add {
         $dist->{date_updated}    ||= 0;
         $dist->{date_added}      ||= 0;
         $dist->{dist_source}     ||= 'unknown';
+        $dist->{stargazer_url}   ||= 'unknown';
+        $dist->{issue_url}       ||= 'unknown';
         $dist->{files}           //= '{}';
 
         my $res = $db->resultset('Dist')->update_or_create({
@@ -89,7 +91,7 @@ sub add {
             dist_build_id => { id => $dist->{build_id} },
             (map +( $_ => $dist->{$_} ),
                 qw/name  meta_url  url  repo_url  description  stars  issues
-                    date_updated  date_added  appveyor_url  files/,
+                    date_updated  date_added  appveyor_url  files  stargazer_url  issue_url/,
             ),
         });
 

--- a/lib/ModulesPerl6/Model/Dists/Schema/Result/Dist.pm
+++ b/lib/ModulesPerl6/Model/Dists/Schema/Result/Dist.pm
@@ -11,6 +11,8 @@ column         appveyor_status => { data_type => 'text', is_foreign_key => 1 };
 column         appveyor_url  => { data_type => 'text',                     };
 column         url           => { data_type => 'text'                      };
 column         repo_url      => { data_type => 'text'                      };
+column         stargazer_url => { data_type => 'text'                      };
+column         issue_url     => { data_type => 'text'                      };
 column         description   => { data_type => 'text'                      };
 column         files         => { data_type => 'text'                      };
 column         stars         => { data_type => 'integer'                   };

--- a/templates/root/search.html.ep
+++ b/templates/root/search.html.ep
@@ -51,13 +51,13 @@
         ><%= $dist->{name} %></a>
           <b><%= $dist->{description} %></b></h2>
       <ul>
-        % if ($dist->{dist_source} eq 'github') {
+        % if ($dist->{stargazer_url} ne 'unknown') {
           <li title="Number of likes" data-toggle="tooltip"
-            ><a href="<%= $dist->{url} . '/stargazers' %>"
+            ><a href="<%= $dist->{stargazer_url} %>"
             ><i class="glyphicon glyphicon-star"></i>
               <%= $dist->{stars} %></a></li>
           <li title="Number of open Issues" data-toggle="tooltip"
-            ><a href="<%= $dist->{url} . '/issues' %>"
+            ><a href="<%= $dist->{issue_url} %>"
             ><i class="glyphicon glyphicon-info-sign"></i>
               <%= $dist->{issues} %></a></li>
         % } else {


### PR DESCRIPTION
Current modules.perl6.org doesn't show the stars or issues of the modules on CPAN.
This fix partially (there is gitlab other than github) solve this problem.