### PR TITLE
Add --delete option to rsync for CPAN dists

### DIFF
--- a/lib/ModulesPerl6/DbBuilder.pm
+++ b/lib/ModulesPerl6/DbBuilder.pm
@@ -135,7 +135,7 @@ sub _cpan_metas {
     else {
         log info => 'rsyncing CPAN dists from ' .CPAN_RSYNC_URL;
         my @command = (qw{
-            /usr/bin/rsync  --prune-empty-dirs  -av
+            /usr/bin/rsync  --prune-empty-dirs  --delete  -av
             --exclude="/id/P/PS/PSIXDISTS/Perl6"
             --include="/id/*/*/*/Perl6/"
             --include="/id/*/*/*/Perl6/*.meta"


### PR DESCRIPTION
The build log warns about a strange file. It was removed from CPAN, but may be still around on modules.perl6.org rsync mirror:

```
[Wed May  9 17:20:08 2018] [warn] Could not figure out name and version for dist: id/U/UG/UGEXE/Perl6/v0.1.30.meta
```

Maybe easier to just delete the specific file, but adding "--delete" (hopefully) won't cause any harm.