### PR TITLE
Update donation URL

### DIFF
--- a/templates/layouts/default.html.ep
+++ b/templates/layouts/default.html.ep
@@ -54,7 +54,7 @@
   </nav>
 
   <div class="container">
-    <p id="donation-bar">Help language development. <a href="https://donate.perlfoundation.org/">Donate to The Perl Foundation</a></p>
+    <p id="donation-bar">Help language development. <a href="https://www.perlfoundation.org/donate.html">Donate to The Perl Foundation</a></p>
 
     <%= content %>
     <footer>


### PR DESCRIPTION
The page under the donate subdomain doesn't seem to be the correct place to go. Many of the links on the page lead to 404s.